### PR TITLE
Fix UI and CORS

### DIFF
--- a/src/main/java/edu/kit/datamanager/metastore2/configuration/WebSecurityConfig.java
+++ b/src/main/java/edu/kit/datamanager/metastore2/configuration/WebSecurityConfig.java
@@ -108,7 +108,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
     final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
-    config.addAllowedOrigin("*"); // @Value: http://localhost:8080
+    //config.addAllowedOrigin("*"); // @Value: http://localhost:8080
+    config.addAllowedOriginPattern("*");
     config.addAllowedHeader("*");
     config.addAllowedMethod("*");
     config.addExposedHeader("Content-Range");

--- a/src/main/java/edu/kit/datamanager/metastore2/web/impl/SchemaRegistryControllerUIImpl.java
+++ b/src/main/java/edu/kit/datamanager/metastore2/web/impl/SchemaRegistryControllerUIImpl.java
@@ -147,7 +147,7 @@ public class SchemaRegistryControllerUIImpl implements ISchemaRegistryController
         JSONObject obj = null;
         try {
             obj = (JSONObject) parser.parse(
-                    new InputStreamReader(resource.getInputStream(), "UTF-8"));
+                    new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -165,7 +165,7 @@ public class SchemaRegistryControllerUIImpl implements ISchemaRegistryController
         TabulatorItems[] items = null;
         Resource resource = new ClassPathResource(path);
         try {
-            items = mapper.readValue(Files.newBufferedReader(Paths.get(resource.getURI()), StandardCharsets.UTF_8), TabulatorItems[].class);
+            items = mapper.readValue(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8), TabulatorItems[].class);
         } catch (IOException ex) {
             Logger.getLogger(SchemaRegistryControllerUIImpl.class.getName()).log(Level.SEVERE, null, ex);
         }


### PR DESCRIPTION
1. Starting metastore throws an exception and request from other locations do not work anymore:
```
java.lang.IllegalArgumentException: When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header. To allow credentials to a set of origins, list them explicitly or consider using "allowedOriginPatterns" instead.
```
---

2. Requesting webUI fails with Error 500, a FileNotFound Exception is thrown. This has something to do with running the service as JAR and the filesystem abstraction.